### PR TITLE
Update CI to use Ubuntu 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   linters:
     name: Markdown linting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Using Ubuntu 20.04 for action runners [is now deprecated](https://github.com/actions/runner-images/issues/11101#top). This PR updates the CI to instead use Ubuntu 24